### PR TITLE
Re #4 - adds keycloak subchart + examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This format tries to follow the [Common Changelog](https://common-changelog.org/) format.
 
+## 0.0.6 - 2025-10-XX
+
+- Added KeyCloak charts and updated example configuration. (TBD...)
+
 ## 0.0.5 - 2025-04-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ This chart currently consists of:
 - the message broker (with a common configuration - currently, just RabbitMQ)
 - the data plane (currently, just MINIO)
 - [broker-http-proxy](https://github.com/INTERSECT-SDK/broker-http-proxy/)
+- identity management / authentication ([keycloak](https://www.keycloak.org/))
 
 Future applications we will include in this chart will be:
 
+- [Registry service](https://github.com/INTERSECT-SDK/registry-service)
 - iHub
 
 ## Chart usage

--- a/charts/intersect-core/Chart.yaml
+++ b/charts/intersect-core/Chart.yaml
@@ -27,3 +27,10 @@ dependencies:
     name: minio
     version: "14.x.x"
     repository: "oci://registry-1.docker.io/bitnamicharts"
+
+  # identity provider / authentication
+  - alias: intersect-authentication-1
+    condition: intersect-authentication-1.enabled
+    name: keycloak
+    version: "25.x.x"
+    repository: "oci://registry-1.docker.io/bitnamicharts"

--- a/charts/intersect-core/values.yaml
+++ b/charts/intersect-core/values.yaml
@@ -275,3 +275,85 @@ intersect-storage-1:
 
   gateway:
     enabled: false
+
+####################################################
+### IDENTITY PROVIDER / AUTHENTICATION SUBCHARTS ###
+####################################################
+# Configure identity provider
+
+# for latest documentation, see https://github.com/bitnami/charts/blob/main/bitnami/minio/values.yaml
+intersect-authentication-1:
+  enabled: true
+  
+  auth:
+    adminUser: "intersect-auth-user"
+    adminPassword: "intersect-auth-password"
+
+  production: false
+
+  proxyHeaders: ""
+
+  # Need to enable unless running via Ingress, such as NodePort  
+  tls:
+    enabled: false
+  
+  adminRealm: "master"
+  
+  httpEnabled: false
+
+  httpRelativePath: "/"
+
+  # @param logging.level Allowed values as documented: FATAL, ERROR, WARN, INFO, DEBUG, TRACE, ALL, OFF
+  logging:
+    output: default
+    level: WARN
+
+  # @param existingConfigmap Name of existing ConfigMap with Keycloak configuration
+  existingConfigmap: ""
+
+  extraStartupArgs: ""
+
+  initdbScripts: {}
+
+  deployment:
+    updateStrategy:
+      type: RollingUpdate
+
+  ingress:
+    enabled: false
+    path: /auth/intersect-authentication-1
+
+  networkPolicy:
+    enabled: false
+
+  # TODO consider setting this to "true" eventually
+  persistence:
+    enabled: false
+
+  volumePermissions:
+    enabled: false
+    resources:
+      limits: {}
+      requests: {}
+
+  serviceAccount:
+    create: false
+
+  # This should be enabled at runtime because developers probably won't have Prometheus configured on their machine.
+  metrics:
+    enabled: false
+
+  postgresql:
+    enabled: true
+    image:
+      repository: bitnamilegacy/postgresql
+    primary:
+      persistence:
+        enabled: false
+    nameOverride: "intersect-authentication-1-postgres"
+    auth:
+      username: bn_keycloak
+      password: ""
+      database: bitnami_keycloak
+    architecture: standalone
+

--- a/examples/example-chart.values.yaml
+++ b/examples/example-chart.values.yaml
@@ -56,7 +56,13 @@
     username: &minio-username "data"
     password: &minio-password "data_password"
     nodePort: &minio-nodePort 30020
-    consoleNodePort: &minio-consoleNodePort 30021    
+    consoleNodePort: &minio-consoleNodePort 30021
+  
+  # identity provider
+  keycloak:
+    username: &keycloak-username "keycloak_user"
+    password: &keycloak-password "keycloak_password"
+    nodePort: &keycloak-nodePort 30030
 
 ###################################
 ##### UI/MICROSERVICE SUBCHARTS ###
@@ -175,3 +181,19 @@ intersect-storage-1:
       # memory: "128Mi"
       # cpu: "16"
       ephemeral-storage: "4Gi"
+
+####################################################
+### IDENTITY PROVIDER / AUTHENTICATION SUBCHARTS ###
+####################################################
+# Configure identity provider
+
+intersect-authentication-1:
+  auth:
+    adminUser: *keycloak-username
+    adminPassword: *keycloak-password
+
+  # this example will use a NodePort service
+  service:
+    type: NodePort
+    nodePorts:    
+      http: *keycloak-nodePort


### PR DESCRIPTION
Work includes:
  - adds subchart for keycloak from bitnami
  - updates README for this new subchart
  - initial update to CHANGELOG
  
To test:
  - we manually created a input values.yaml test and deployed to our ORC K8s cluster; worked! :tada: 