### PR TITLE
Fixes the node port names for minio values in examples

### DIFF
--- a/examples/example-chart.values.yaml
+++ b/examples/example-chart.values.yaml
@@ -170,8 +170,8 @@ intersect-storage-1:
   service:
     type: NodePort
     nodePorts:    
-      nodePort: *minio-nodePort
-      consoleNodePort: *minio-consoleNodePort
+      api: *minio-nodePort
+      console: *minio-consoleNodePort
   resources:
     requests:
       # memory: "64Mi"


### PR DESCRIPTION
From @Lance-Drane work, found the correct names for minio:
  - https://github.com/bitnami/charts/blob/163a43f4443e89720a5eb931309c1f41d26f8fcf/bitnami/minio/values.yaml